### PR TITLE
Upgrade marked from 0.3.6 to 0.3.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -296,9 +296,9 @@
       }
     },
     "marked": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
-      "integrity": "sha1-ssbGGPzOzk74bE/Gy4p8v1rtqNc="
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.9.tgz",
+      "integrity": "sha512-nW5u0dxpXxHfkHzzrveY45gCbi+R4PaO4WRZYqZNl+vB0hVGeqlFn0aOg1c8AKL63TrNFn9Bm2UP4AdiZ9TPLw=="
     },
     "mocha": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/tcort/markdown-link-extractor",
   "dependencies": {
-    "marked": "^0.3.6"
+    "marked": "^0.3.9"
   },
   "devDependencies": {
     "expect.js": "^0.3.1",


### PR DESCRIPTION
marked@0.3.6 has a [security vulnerability](https://github.com/chjj/marked/releases/tag/0.3.9) (XSS) that shows up on GitHub repositories that use it.