### PR TITLE
Support image size in image links

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,13 +6,21 @@ module.exports = function markdownLinkExtractor(markdown) {
     var links = [];
 
     var renderer = new marked.Renderer();
+
+    // Taken from https://github.com/markedjs/marked/issues/1279
+    var linkWithImageSizeSupport = /^!?\[((?:\[[^\[\]]*\]|\\[\[\]]?|`[^`]*`|[^\[\]\\])*?)\]\(\s*(<(?:\\[<>]?|[^\s<>\\])*>|(?:\\[()]?|\([^\s\x00-\x1f()\\]*\)|[^\s\x00-\x1f()\\])*?(?:\s+=(?:[\w%]+)?x(?:[\w%]+)?)?)(?:\s+("(?:\\"?|[^"\\])*"|'(?:\\'?|[^'\\])*'|\((?:\\\)?|[^)\\])*\)))?\s*\)/;
+
+    marked.InlineLexer.rules.normal.link = linkWithImageSizeSupport;
+    marked.InlineLexer.rules.gfm.link = linkWithImageSizeSupport;
+    marked.InlineLexer.rules.breaks.link = linkWithImageSizeSupport;
+    
     renderer.link = function (href, title, text) {
         links.push(href);
-        return marked.Renderer.prototype.link.apply(this, arguments);
     };
     renderer.image = function (href, title, text) {
+        // Remove image size at the end, e.g. ' =20%x50'
+        href = href.replace(/ =\d*%?x\d*%?$/, "");
         links.push(href);
-        return marked.Renderer.prototype.image.apply(this, arguments);
     };
     marked(markdown, { renderer: renderer });
 

--- a/test/markdown-link-extractor.test.js
+++ b/test/markdown-link-extractor.test.js
@@ -32,6 +32,20 @@ describe('markdown-link-extractor', function () {
         expect(links[0]).to.be('http://www.example.com/image.jpg');
     });
 
+    it('should extract an image link in a ![tag](foo/image.jpg)', function () {
+        var links = markdownLinkExtractor('![example](foo/image.jpg)');
+        expect(links).to.be.an('array');
+        expect(links).to.have.length(1);
+        expect(links[0]).to.be('foo/image.jpg');
+    });
+
+    it('should extract an image link in a ![tag](foo/image.jpg =20%x50)', function () {
+        var links = markdownLinkExtractor('![example](foo/image.jpg =20%x50)');
+        expect(links).to.be.an('array');
+        expect(links).to.have.length(1);
+        expect(links[0]).to.be('foo/image.jpg');
+    });
+
     it('should extract a bare link http://example.com', function () {
         var links = markdownLinkExtractor('This is a link: http://www.example.com');
         expect(links).to.be.an('array');


### PR DESCRIPTION
Addresses https://github.com/tcort/markdown-link-check/issues/42

I haven't bumped the version number, don't know if I should bump minor or patch as it can be interpreted as a feature or bugfix.

I have removed the prototype calls as these are responsible for the conversion to HTML which is not needed for this case and can potentially improve the performance. Do you agree with that?